### PR TITLE
Get factorio status not working when service is inactive (dead)

### DIFF
--- a/farmbot.py
+++ b/farmbot.py
@@ -67,13 +67,13 @@ def stop_factorio():
 
 
 def status_factorio():
-    command = subprocess.run("systemctl status factorio".split(), capture_output=True)
-    if command.stderr != b'':
+    command = subprocess.run("systemctl status factorio".split(), capture_output=True, text=True)
+    if command.stderr != '':
         status = command.stderr
     else:
         status = command.stdout
     StatusCleanList = []
-    for line in status.decode().split('\n'):
+    for line in status.split('\n'):
         if re.search(r'^\s*CGroup:|--rcon', line):
             break
         StatusCleanList.append(line)

--- a/farmbot.py
+++ b/farmbot.py
@@ -67,7 +67,11 @@ def stop_factorio():
 
 
 def status_factorio():
-    status = subprocess.check_output("systemctl status factorio".split())
+    command = subprocess.run("systemctl status factorio".split(), capture_output=True)
+    if command.stderr != b'':
+        status = command.stderr
+    else:
+        status = command.stdout
     StatusCleanList = []
     for line in status.decode().split('\n'):
         if re.search(r'^\s*CGroup:|--rcon', line):


### PR DESCRIPTION
- Convert from check_output to run on factorio status command to handle other exit codes and change status depending on output
- Change factorio status command to use text and remove decoding in function